### PR TITLE
jlogctl: fix getopt use

### DIFF
--- a/jlogctl.c
+++ b/jlogctl.c
@@ -265,10 +265,9 @@ int
 main(int argc, char **argv)
 {
   char *subscriber = NULL;
-  int optind = 0;
   int i, c;
 
-  while ((c = getopt_long(argc, argv, "a:e:dsilrcp:v", NULL, &optind)) != EOF) {
+  while ((c = getopt_long(argc, argv, "a:e:dsilrcp:v", NULL, NULL)) != EOF) {
     switch(c) {
     case 'v':
       verbose = 1;


### PR DESCRIPTION
Before this change, jlogctl treates its argv[0] and options as filenames to attempt to open:

```
$ ./jlogctl -d /tmp/vtc.49967.6b8b4567/vtc_jlog_foo
./jlogctl
error opening './jlogctl'
-d
error opening '-d'
/tmp/vtc.49967.6b8b4567/vtc_jlog_foo
    00000000 [29 bytes] 0 pending readers
Message 1 at [0] of (16+13)
    time: Thu Jan  2 21:46:30 2014
    mlen: 13
```

Afer this change:

```
$ ./jlogctl -d /tmp/vtc.49967.6b8b4567/vtc_jlog_foo    
/tmp/vtc.49967.6b8b4567/vtc_jlog_foo
    00000000 [29 bytes] 0 pending readers
Message 1 at [0] of (16+13)
    time: Thu Jan  2 21:46:30 2014
    mlen: 13
```
